### PR TITLE
Minor refactoring

### DIFF
--- a/R/Jwt.R
+++ b/R/Jwt.R
@@ -3,10 +3,10 @@
 Jwt <- R6::R6Class('Jwt',
                public = list(
                  decode_function = NULL,
-                 initialize = function(key,auth_pattern = '*', decode_function = jose::jwt_decode_hmac) {
+                 initialize = function(key, auth_pattern = '*', decode_function = jose::jwt_decode_hmac) {
 
-                   assertthat::assert_that(class(key) == 'raw')
-                   assertthat::assert_that(class(decode_function) == 'function')
+                   assertthat::assert_that(is.raw(key))
+                   assertthat::assert_that(is.function(decode_function))
 
                    private$key = key
                    self$decode_function = decode_function
@@ -15,11 +15,13 @@ Jwt <- R6::R6Class('Jwt',
                  name = 'JWT',
                  on_attach = function(server, ...) {
 
-                   if (!server$has_plugin('header_routr')) {
+                   if (!server$has_plugin(paste0(private$attach_to, '_routr')) {
                      router <- routr::RouteStack$new()
                      router$attach_to <- private$attach_to
                      server$attach(router)
                    }
+                   
+                   private$server <- server
 
                    router  <- server$plugins$header_routr
                    auth_route <- self$auth_route_function()
@@ -35,7 +37,7 @@ Jwt <- R6::R6Class('Jwt',
                      if (is.null(req_auth) ) {
                        response$status_with_text(401L)
                        FALSE
-                     }  else if (class(self$check_jwt(req_auth))[1] != 'jwt_claim')  {
+                     }  else if (!self$check_jwt(req_auth))  {
                        response$status_with_text(401L)
                        FALSE
                      } else {
@@ -46,14 +48,21 @@ Jwt <- R6::R6Class('Jwt',
                  },
                  check_jwt = function (jwt) {
 
-                   claim <- tryCatch(self$decode_function(jwt, secret = private$key), error = function(e) {print(e); e})
+                   claim <- tryCatch(self$decode_function(jwt, secret = private$key), error = function(e) e)
 
                    if ('error' %in% class(claim)) {
+                     if (!is.null(private$server)) {
+                       server$log('error', conditionMessage(claim))
+                     } else {
+                       message(conditionMessage(claim))
+                     }
+                     return(FALSE)
+                   } else if (!inherits(claim, 'jwt_claim')) {
                      return(FALSE)
                    } else if (is.null(claim$exp) | (unclass(Sys.time()) > claim$exp)) {
                      return(FALSE)
                    } else {
-                     return(claim)
+                     return(TRUE)
                    }
 
                  },
@@ -65,5 +74,6 @@ Jwt <- R6::R6Class('Jwt',
                ), private = list(
                  key = NULL,
                  attach_to = 'header',
-                 auth_pattern = NULL
+                 auth_pattern = NULL,
+                 server = NULL
                ))


### PR DESCRIPTION
This PR is mainly regarding the code design as I have little experience with JWT. It is generally better to use `is.*(x)` or `inherits(x, *)` than `class(x) == *` as it always returns a single boolean. Further I have made changes to use the logging infrastructure in `fiery`. Lastly I've refactored the `check_jwt()` method a bit to always return a boolean.